### PR TITLE
Fixed windows/added support for reading USE/DEF flags in extrusions

### DIFF
--- a/include/cybergarage/x3d/ExtrusionNode.h
+++ b/include/cybergarage/x3d/ExtrusionNode.h
@@ -17,6 +17,8 @@ namespace CyberX3D {
 
 class ExtrusionNode : public Geometry3DNode 
 {
+    SFString *useField;
+	SFString *defField;
 	SFBool *beginCapField;
 	SFBool *endCapField;
 	SFBool *convexField;
@@ -38,6 +40,9 @@ public:
 	////////////////////////////////////////////////
 	
 	SFBool *getBeginCapField() const;
+
+    SFString *getDEF() const;
+	SFString *getUSE() const;
 
 	void setBeginCap(bool value);
 	void setBeginCap(int value);

--- a/include/cybergarage/x3d/FileGIF89a.h
+++ b/include/cybergarage/x3d/FileGIF89a.h
@@ -47,11 +47,6 @@ typedef struct {
 	unsigned int		transparencyColorIndex;
 } GIF89aImage;
 
-#if !R && !G && !B
-#define R	0
-#define G	1
-#define B	2
-#endif
 
 #define GIF89A_LZW_TABLE_SIZE	4096
 

--- a/include/cybergarage/x3d/FileImage.h
+++ b/include/cybergarage/x3d/FileImage.h
@@ -21,14 +21,12 @@
 
 namespace CyberX3D {
 
-#if !R && !G && !B
-#define R	0
-#define G	1
-#define B	2
-#endif
-
 typedef unsigned char RGBColor24[3];
 typedef unsigned char RGBAColor32[4];
+
+const int R = 0;
+const int G = 1;
+const int B = 2;
 
 class FileImage {
 

--- a/include/cybergarage/x3d/NodeString.h
+++ b/include/cybergarage/x3d/NodeString.h
@@ -78,6 +78,9 @@ const char worldInfoNodeString[] = "WorldInfo";
 * Field Constants
 ******************************************************************/
 
+const char useFieldString[] = "USE";
+const char defFieldString[] = "DEF";
+
 const char ambientIntensityFieldString[] = "ambientIntensity";
 const char attenuationFieldString[] = "attenuation";
 const char autoOffsetFieldString[] = "autoOffset";

--- a/sample/Makefile.am
+++ b/sample/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = X3DBrowser x3d2vrml vrml2x3d
+SUBDIRS = 

--- a/src/cybergarage/x3d/ExtrusionNode.cpp
+++ b/src/cybergarage/x3d/ExtrusionNode.cpp
@@ -33,7 +33,15 @@ ExtrusionNode::ExtrusionNode()
 	///////////////////////////
 	// Field 
 	///////////////////////////
-		
+	
+	// USE field
+	useField = new SFString();
+	addField(useFieldString, useField);
+
+	// DEF field
+	defField = new SFString();
+	addField(defFieldString, defField);
+
 	// beginCap field
 	beginCapField = new SFBool(true);
 	addField(beginCapFieldString, beginCapField);
@@ -116,6 +124,16 @@ SFBool *ExtrusionNode::getBeginCapField() const
 	if (isInstanceNode() == false)
 		return beginCapField;
 	return (SFBool *)getField(beginCapFieldString);
+}
+
+SFString *ExtrusionNode::getDEF() const
+{
+    return (SFString *)getField(defFieldString);
+}
+
+SFString *ExtrusionNode::getUSE() const
+{  
+    return (SFString *)getField(useFieldString);
 }
 	
 void ExtrusionNode::setBeginCap(bool value) 

--- a/src/cybergarage/x3d/SceneGraph.cpp
+++ b/src/cybergarage/x3d/SceneGraph.cpp
@@ -286,7 +286,9 @@ bool SceneGraph::save(const char *filename, void (*callbackFn)(int nNode, void *
 ///////////////////////////////////////////////////////////////
 bool SceneGraph::save(const wchar_t *filename, void (*callbackFn)(int nNode, void *info), void *callbackFnInfo)
 {
-	std::ofstream outputFile(filename);
+    char nonsense[100];
+	wcstombs(nonsense, filename, 100);
+	std::ofstream outputFile(nonsense);
 
 	if (!outputFile)
 		return false;
@@ -341,7 +343,9 @@ bool SceneGraph::saveXML(const char *filename, void (*callbackFn)(int nNode, voi
 ////////////////////////////////////////////////////////////////
 bool SceneGraph::saveXML(const wchar_t *filename, void (*callbackFn)(int nNode, void *info), void *callbackFnInfo)
 {
-	std::ofstream outputFile(filename);
+    char nonsense[100];
+	wcstombs(nonsense,filename,100);
+	std::ofstream outputFile(nonsense);
 
 	if (!outputFile)
 		return false;


### PR DESCRIPTION
I had a need to use this library on Windows with MinGW GCC, and I had some trouble compiling certain modules, so I made some changes.  I also had a need to use the DEF/USE attributes for extrusion nodes, so those were added as well.